### PR TITLE
Refactor and optimise camera driver code quality

### DIFF
--- a/ASCOM.HomeMade.SBIGCamera/SBIGCamera.cs
+++ b/ASCOM.HomeMade.SBIGCamera/SBIGCamera.cs
@@ -60,7 +60,8 @@ namespace ASCOM.HomeMade.SBIGCamera
         internal string DriverID { get { return "ASCOM.HomeMade.SBIGCamera"; } }
         // TODO Change the descriptive string for your driver then remove this line
         protected DateTime lastTECRead = DateTime.Now;
-        protected static TimeSpan TEMPERATURETTL = TimeSpan.FromMilliseconds(500); // In ms
+        private const int TemperatureCacheTtlMs = 500;
+        protected static TimeSpan TEMPERATURETTL = TimeSpan.FromMilliseconds(TemperatureCacheTtlMs);
 
         protected BackgroundWorker imagingWorker = null;
         protected ImageTakerThread imagetaker = null;
@@ -128,30 +129,18 @@ namespace ASCOM.HomeMade.SBIGCamera
         public void CommandBlind(string command, bool raw)
         {
             CheckConnected("CommandBlind");
-            // Call CommandString and return as soon as it finishes
-            this.CommandString(command, raw);
-            // or
             throw new ASCOM.MethodNotImplementedException("CommandBlind");
-            // DO NOT have both these sections!  One or the other
         }
 
         public bool CommandBool(string command, bool raw)
         {
             CheckConnected("CommandBool");
-            string ret = CommandString(command, raw);
-            // TODO decode the return string and return true or false
-            // or
             throw new ASCOM.MethodNotImplementedException("CommandBool");
-            // DO NOT have both these sections!  One or the other
         }
 
         public string CommandString(string command, bool raw)
         {
             CheckConnected("CommandString");
-            // it's a good idea to put all the low level communication with the device here,
-            // then all communication calls this function
-            // you need something to ensure that only one command is in progress at a time
-
             throw new ASCOM.MethodNotImplementedException("CommandString");
         }
 

--- a/ASCOM.HomeMade.SBIGClient/ImageTakerThread.cs
+++ b/ASCOM.HomeMade.SBIGClient/ImageTakerThread.cs
@@ -124,7 +124,6 @@ namespace ASCOM.HomeMade.SBIGClient
                     return;
                 }
 
-                //cameraImageArray = SBIG.WaitEndAndReadoutExposure32(exposureParams2);
                 while (server.ExposureInProgress(exposureParams2)) 
                 {
                     if (StopExposure)
@@ -163,7 +162,6 @@ namespace ASCOM.HomeMade.SBIGClient
                                     camera.cameraImageArray.SetValue(redPixel, x, y);
                                 }
                         }
-                //camera.cameraImageArray = Utils.RotateMatrixCounterClockwiseAndConvertToInt(data);
                 data = null;
                 debug.LogMessage("ImageTakerThread TakeImage", "Finishing readout");
 
@@ -174,7 +172,9 @@ namespace ASCOM.HomeMade.SBIGClient
             catch (Exception e)
             {
                 debug.LogMessage("ImageTakerThread TakeImage", "Error: " + Utils.DisplayException(e));
-                //throw;
+                camera.LastError = e;
+                camera.cameraImageReady = false;
+                camera.CurrentCameraState = CameraStates.cameraIdle;
             }
             finally
             {

--- a/ASCOM.HomeMade.SBIGClient/SBIGClient.cs
+++ b/ASCOM.HomeMade.SBIGClient/SBIGClient.cs
@@ -82,7 +82,7 @@ namespace ASCOM.HomeMade.SBIGClient
 
         #region Communication with service
 
-        private SBIGResponse SendMessage(string type, SBIG.PAR_COMMAND command = (SBIG.PAR_COMMAND)0, object payload = null)
+        private SBIGResponse SendMessage(MessageType type, SBIG.PAR_COMMAND command = (SBIG.PAR_COMMAND)0, object payload = null)
         {
             try
             {
@@ -97,7 +97,7 @@ namespace ASCOM.HomeMade.SBIGClient
             }
         }
 
-        private SBIGResponse SendMessage(string type) // Timeout in ms
+        private SBIGResponse SendMessage(MessageType type)
         {
             return SendMessage(type, 0, null);
         }
@@ -125,7 +125,7 @@ namespace ASCOM.HomeMade.SBIGClient
         {
             debug.LogMessage("SBIGClient", "CC_SET_TEMPERATURE_REGULATION2");
             if (!IsConnected) throw new ApplicationException("Not connected to server");
-            SBIGResponse response = SendMessage("CC_SET_TEMPERATURE_REGULATION2", SBIG.PAR_COMMAND.CC_SET_TEMPERATURE_REGULATION2, tparam);
+            SBIGResponse response = SendMessage(MessageType.SetTemperatureRegulation, SBIG.PAR_COMMAND.CC_SET_TEMPERATURE_REGULATION2, tparam);
             if (response.error != null) throw response.error;
         }
 
@@ -133,7 +133,7 @@ namespace ASCOM.HomeMade.SBIGClient
         {
             debug.LogMessage("SBIGClient", "CC_START_EXPOSURE2");
             if (!IsConnected) throw new ApplicationException("Not connected to server");
-            SBIGResponse response = SendMessage("CC_START_EXPOSURE2", SBIG.PAR_COMMAND.CC_START_EXPOSURE2, tparam);
+            SBIGResponse response = SendMessage(MessageType.StartExposure, SBIG.PAR_COMMAND.CC_START_EXPOSURE2, tparam);
             if (response.error != null) throw response.error;
         }
 
@@ -141,7 +141,7 @@ namespace ASCOM.HomeMade.SBIGClient
         {
             debug.LogMessage("SBIGClient", "CC_QUERY_TEMPERATURE_STATUS");
             if (!IsConnected) throw new ApplicationException("Not connected to server");
-            SBIGResponse response = SendMessage("CC_QUERY_TEMPERATURE_STATUS", SBIG.PAR_COMMAND.CC_QUERY_TEMPERATURE_STATUS, new SBIG.QueryTemperatureStatusParams()
+            SBIGResponse response = SendMessage(MessageType.QueryTemperatureStatus, SBIG.PAR_COMMAND.CC_QUERY_TEMPERATURE_STATUS, new SBIG.QueryTemperatureStatusParams()
             {
                 request = SBIG.QUERY_TEMP_STATUS_REQUEST.TEMP_STATUS_ADVANCED2
             });
@@ -153,7 +153,7 @@ namespace ASCOM.HomeMade.SBIGClient
         {
             debug.LogMessage("SBIGClient", "CCD_INFO");
             if (!IsConnected) throw new ApplicationException("Not connected to server");
-            SBIGResponse response = SendMessage("CCD_INFO", SBIG.PAR_COMMAND.CC_GET_CCD_INFO, tparams);
+            SBIGResponse response = SendMessage(MessageType.CcdInfo, SBIG.PAR_COMMAND.CC_GET_CCD_INFO, tparams);
             if (response.error != null) throw response.error;
             return (SBIG.GetCCDInfoResults0)response.payload;
         }
@@ -162,7 +162,7 @@ namespace ASCOM.HomeMade.SBIGClient
         {
             debug.LogMessage("SBIGClient", "CCD_INFO_EXTENDED");
             if (!IsConnected) throw new ApplicationException("Not connected to server");
-            SBIGResponse response = SendMessage("CCD_INFO_EXTENDED", SBIG.PAR_COMMAND.CC_GET_CCD_INFO, tparams);
+            SBIGResponse response = SendMessage(MessageType.CcdInfoExtended, SBIG.PAR_COMMAND.CC_GET_CCD_INFO, tparams);
             if (response.error != null) throw response.error;
             return (SBIG.GetCCDInfoResults2)response.payload;
         }
@@ -171,7 +171,7 @@ namespace ASCOM.HomeMade.SBIGClient
         {
             debug.LogMessage("SBIGClient", "CCD_INFO_EXTENDED2");
             if (!IsConnected) throw new ApplicationException("Not connected to server");
-            SBIGResponse response = SendMessage("CCD_INFO_EXTENDED2", SBIG.PAR_COMMAND.CC_GET_CCD_INFO, tparams);
+            SBIGResponse response = SendMessage(MessageType.CcdInfoExtended2, SBIG.PAR_COMMAND.CC_GET_CCD_INFO, tparams);
             if (response.error != null) throw response.error;
             return (SBIG.GetCCDInfoResults4)response.payload;
         }
@@ -180,7 +180,7 @@ namespace ASCOM.HomeMade.SBIGClient
         {
             debug.LogMessage("SBIGClient", "CCD_INFO_EXTENDED3");
             if (!IsConnected) throw new ApplicationException("Not connected to server");
-            SBIGResponse response = SendMessage("CCD_INFO_EXTENDED3", SBIG.PAR_COMMAND.CC_GET_CCD_INFO, tparams);
+            SBIGResponse response = SendMessage(MessageType.CcdInfoExtended3, SBIG.PAR_COMMAND.CC_GET_CCD_INFO, tparams);
             if (response.error != null) throw response.error;
             return (SBIG.GetCCDInfoResults6)response.payload;
         }
@@ -189,7 +189,7 @@ namespace ASCOM.HomeMade.SBIGClient
         {
             debug.LogMessage("SBIGClient", "CCD_INFO_EXTENDED_PIXCEL");
             if (!IsConnected) throw new ApplicationException("Not connected to server");
-            SBIGResponse response = SendMessage("CCD_INFO_EXTENDED_PIXCEL", SBIG.PAR_COMMAND.CC_GET_CCD_INFO, tparams);
+            SBIGResponse response = SendMessage(MessageType.CcdInfoExtendedPixcel, SBIG.PAR_COMMAND.CC_GET_CCD_INFO, tparams);
             if (response.error != null) throw response.error;
             return (SBIG.GetCCDInfoResults3)response.payload;
         }
@@ -198,7 +198,7 @@ namespace ASCOM.HomeMade.SBIGClient
         {
             debug.LogMessage("SBIGClient", "AbortExposure");
             if (!IsConnected) throw new ApplicationException("Not connected to server");
-            SBIGResponse response = SendMessage("AbortExposure", 0, sep2);
+            SBIGResponse response = SendMessage(MessageType.AbortExposure, 0, sep2);
             if (response.error != null) throw response.error;
         }
 
@@ -206,7 +206,7 @@ namespace ASCOM.HomeMade.SBIGClient
         {
             debug.LogMessage("SBIGClient", "EndReadout");
             if (!IsConnected) throw new ApplicationException("Not connected to server");
-            SBIGResponse response = SendMessage("EndReadout", 0, ccd);
+            SBIGResponse response = SendMessage(MessageType.EndReadout, 0, ccd);
             if (response.error != null) throw response.error;
         }
 
@@ -214,7 +214,7 @@ namespace ASCOM.HomeMade.SBIGClient
         {
             debug.LogMessage("SBIGClient", "ExposureInProgress");
             if (!IsConnected) throw new ApplicationException("Not connected to server");
-            SBIGResponse response = SendMessage("ExposureInProgress", 0, tparam);
+            SBIGResponse response = SendMessage(MessageType.ExposureInProgress, 0, tparam);
             if (response.error != null) throw response.error;
             return (bool)response.payload;
         }
@@ -223,7 +223,7 @@ namespace ASCOM.HomeMade.SBIGClient
         {
             debug.LogMessage("SBIGClient", "ReadoutData");
             if (!IsConnected) throw new ApplicationException("Not connected to server");
-            SBIGResponse response = SendMessage("ReadoutData", 0, sep2);
+            SBIGResponse response = SendMessage(MessageType.ReadoutData, 0, sep2);
             if (response.error != null) throw response.error;
             return (UInt16[])response.payload;
         }
@@ -234,7 +234,7 @@ namespace ASCOM.HomeMade.SBIGClient
         {
             debug.LogMessage("SBIGClient", "CC_CFW");
             if (!IsConnected) throw new ApplicationException("Not connected to server");
-            SBIGResponse response = SendMessage("CC_CFW", SBIG.PAR_COMMAND.CC_CFW, tparams);
+            SBIGResponse response = SendMessage(MessageType.CcfCfw, SBIG.PAR_COMMAND.CC_CFW, tparams);
             if (response.error != null) throw response.error;
             return (SBIG.CFWResults)response.payload;
         }

--- a/ASCOM.HomeMade.SBIGCommon/Debug.cs
+++ b/ASCOM.HomeMade.SBIGCommon/Debug.cs
@@ -42,8 +42,9 @@ namespace ASCOM.HomeMade.SBIGCommon
 
         public void LogMessage(string identifier, string message, params object[] args)
         {
+            var now = DateTime.Now;
             var msg = string.Format(message, args);
-            LogMessage(DateTime.Now.Day+"/"+ DateTime.Now.Month+"/"+ DateTime.Now.Year + " " + DateTime.Now.Hour+":"+ DateTime.Now.Minute+":"+ DateTime.Now.Second+"."+ DateTime.Now.Millisecond + ": " + identifier + ": " + msg);
+            LogMessage($"{now:dd/MM/yyyy HH:mm:ss.fff}: {identifier}: {msg}");
         }
 
         readonly object fileLockObject = new object();

--- a/ASCOM.HomeMade.SBIGCommon/MemoryController.cs
+++ b/ASCOM.HomeMade.SBIGCommon/MemoryController.cs
@@ -28,7 +28,7 @@ namespace ASCOM.HomeMade.SBIGCommon
 {
     public class MemoryController
     {
-        private const int MAXMEMORY = 500;
+        private const int MaxMemoryMB = 500;
 
         public MemoryController()
         {
@@ -38,7 +38,7 @@ namespace ASCOM.HomeMade.SBIGCommon
         public void ControlMemory()
         {
             float memoryUsed = MemoryUsed();
-            if (memoryUsed>MAXMEMORY)
+            if (memoryUsed > MaxMemoryMB)
             {
                 GCSettings.LargeObjectHeapCompactionMode = GCLargeObjectHeapCompactionMode.CompactOnce;
                 GC.Collect();

--- a/ASCOM.HomeMade.SBIGCommon/SBIGHandler.cs
+++ b/ASCOM.HomeMade.SBIGCommon/SBIGHandler.cs
@@ -39,7 +39,9 @@ namespace ASCOM.HomeMade.SBIGCommon
 
         public const string deviceId = "ASCOM.HomeMade.SBIGCamera";
         private static Dictionary<SBIG.CCD_REQUEST, Exposure> exposures = new Dictionary<SBIG.CCD_REQUEST, Exposure>();
-        private static bool lockAccess = false;
+        private static readonly object _cameraLockObject = new object();
+        private static readonly object _accessLockObject = new object();
+        private static readonly object _readoutLockObject = new object();
         private Debug debug = null;
         private bool _Connected = false;
 
@@ -58,24 +60,12 @@ namespace ASCOM.HomeMade.SBIGCommon
             debug = new Debug(deviceId, Path.Combine(strPath, "SBIGCommon_" + DateTime.Now.Year + DateTime.Now.Month + DateTime.Now.Day + DateTime.Now.Hour + DateTime.Now.Minute + DateTime.Now.Second + DateTime.Now.Millisecond + ".log"));
         }
 
-        private static bool cameraLock = false;
         public SBIGResponse Transmit(SBIGRequest request)
         {
-            SBIGResponse temp = null;
-            try
+            lock (_cameraLockObject)
             {
-                Utils.AcquireLock(ref cameraLock);
-                temp = HandleMessage(request);
+                return HandleMessage(request);
             }
-            catch(Exception)
-            {
-                throw;
-            }
-            finally
-            {
-                Utils.ReleaseLock(ref cameraLock);
-            }
-            return temp;
         }
 
         private SBIGResponse HandleMessage(SBIGRequest request)
@@ -87,133 +77,126 @@ namespace ASCOM.HomeMade.SBIGCommon
 
                 switch (request.type)
                 {
-                    case "PING":
+                    case MessageType.Ping:
                         response.payload = true;
                         break;
-                    case "Connect":
-                        string ip = "";
-                        ip = (string)request.parameters;
-                        response.payload = Connect(ip);
+                    case MessageType.Connect:
+                        response.payload = Connect((string)request.parameters);
                         break;
-                    case "Disconnect":
+                    case MessageType.Disconnect:
                         Disconnect();
                         response.payload = null;
                         break;
-                    case "AbortExposure":
-                        SBIG.StartExposureParams2 p0 = (SBIG.StartExposureParams2)request.parameters;
-                        if (exposures.Keys.Contains(p0.ccd)) exposures.Remove(p0.ccd);
+                    case MessageType.AbortExposure:
+                        SBIG.StartExposureParams2 abortParams = (SBIG.StartExposureParams2)request.parameters;
+                        if (exposures.Keys.Contains(abortParams.ccd)) exposures.Remove(abortParams.ccd);
                         try
                         {
-                            Utils.AcquireLock(ref lockAccess);
-                            AbortExposure(p0);
+                            lock (_accessLockObject)
+                            {
+                                AbortExposure(abortParams);
+                            }
                         }
                         catch (Exception ex)
                         {
                             debug.LogMessage("SBIGService HandleMessage", "Error: " + Utils.DisplayException(ex));
                         }
-                        finally
+                        response.payload = null;
+                        break;
+                    case MessageType.SetTemperatureRegulation:
+                        SBIG.SetTemperatureRegulationParams2 tempRegParams = (SBIG.SetTemperatureRegulationParams2)request.parameters;
+                        UnivDrvCommand((SBIG.PAR_COMMAND)request.command, tempRegParams);
+                        response.payload = null;
+                        break;
+                    case MessageType.StartExposure:
+                        SBIG.StartExposureParams2 startExpParams = (SBIG.StartExposureParams2)request.parameters;
+                        Exposure exposure = new Exposure() { ccd = startExpParams.ccd, start = DateTime.Now, duration = startExpParams.exposureTime };
+                        if (exposures.Keys.Contains(startExpParams.ccd)) exposures.Remove(startExpParams.ccd);
+                        exposures.Add(startExpParams.ccd, exposure);
+                        UnivDrvCommand((SBIG.PAR_COMMAND)request.command, startExpParams);
+                        response.payload = null;
+                        break;
+                    case MessageType.QueryTemperatureStatus:
+                        SBIG.QueryTemperatureStatusParams tempStatusParams = (SBIG.QueryTemperatureStatusParams)request.parameters;
+                        SBIG.QueryTemperatureStatusResults2 tempStatusResult = new SBIG.QueryTemperatureStatusResults2();
+                        UnivDrvCommand((SBIG.PAR_COMMAND)request.command, tempStatusParams, out tempStatusResult);
+                        response.payload = tempStatusResult;
+                        break;
+                    case MessageType.CcdInfo:
+                        SBIG.GetCCDInfoParams ccdInfoParams = (SBIG.GetCCDInfoParams)request.parameters;
+                        SBIG.GetCCDInfoResults0 ccdInfoResult = new SBIG.GetCCDInfoResults0();
+                        UnivDrvCommand((SBIG.PAR_COMMAND)request.command, ccdInfoParams, out ccdInfoResult);
+                        response.payload = ccdInfoResult;
+                        break;
+                    case MessageType.CcdInfoExtended:
+                        SBIG.GetCCDInfoParams ccdExtParams = (SBIG.GetCCDInfoParams)request.parameters;
+                        SBIG.GetCCDInfoResults2 ccdExtResult = new SBIG.GetCCDInfoResults2();
+                        UnivDrvCommand((SBIG.PAR_COMMAND)request.command, ccdExtParams, out ccdExtResult);
+                        response.payload = ccdExtResult;
+                        break;
+                    case MessageType.CcdInfoExtended2:
+                        SBIG.GetCCDInfoParams ccdExt2Params = (SBIG.GetCCDInfoParams)request.parameters;
+                        SBIG.GetCCDInfoResults4 ccdExt2Result = new SBIG.GetCCDInfoResults4();
+                        UnivDrvCommand((SBIG.PAR_COMMAND)request.command, ccdExt2Params, out ccdExt2Result);
+                        response.payload = ccdExt2Result;
+                        break;
+                    case MessageType.CcdInfoExtended3:
+                        SBIG.GetCCDInfoParams ccdExt3Params = (SBIG.GetCCDInfoParams)request.parameters;
+                        SBIG.GetCCDInfoResults6 ccdExt3Result = new SBIG.GetCCDInfoResults6();
+                        UnivDrvCommand((SBIG.PAR_COMMAND)request.command, ccdExt3Params, out ccdExt3Result);
+                        response.payload = ccdExt3Result;
+                        break;
+                    case MessageType.CcdInfoExtendedPixcel:
+                        SBIG.GetCCDInfoParams ccdPixcelParams = (SBIG.GetCCDInfoParams)request.parameters;
+                        SBIG.GetCCDInfoResults3 ccdPixcelResult = new SBIG.GetCCDInfoResults3();
+                        UnivDrvCommand((SBIG.PAR_COMMAND)request.command, ccdPixcelParams, out ccdPixcelResult);
+                        response.payload = ccdPixcelResult;
+                        break;
+                    case MessageType.EndReadout:
+                        SBIG.CCD_REQUEST endReadoutCcd = (SBIG.CCD_REQUEST)request.parameters;
+                        if (exposures.Keys.Contains(endReadoutCcd)) exposures.Remove(endReadoutCcd);
+                        EndReadout(endReadoutCcd);
+                        response.payload = null;
+                        break;
+                    case MessageType.ExposureInProgress:
+                        bool inProgress = false;
+                        SBIG.StartExposureParams2 inProgressParams = (SBIG.StartExposureParams2)request.parameters;
+                        if (exposures.Keys.Contains(inProgressParams.ccd))
                         {
-                            Utils.ReleaseLock(ref lockAccess);
-                        }
-                        response.payload = null;
-                        break;
-                    case "CC_SET_TEMPERATURE_REGULATION2":
-                        SBIG.SetTemperatureRegulationParams2 p1 = (SBIG.SetTemperatureRegulationParams2)request.parameters;
-                        UnivDrvCommand((SBIG.PAR_COMMAND)request.command, p1);
-                        response.payload = null;
-                        break;
-                    case "CC_START_EXPOSURE2":
-                        SBIG.StartExposureParams2 p2 = (SBIG.StartExposureParams2)request.parameters;
-                        Exposure exposure = new Exposure() { ccd = p2.ccd, start = DateTime.Now, duration = p2.exposureTime };
-                        if (exposures.Keys.Contains(p2.ccd)) exposures.Remove(p2.ccd);
-                        exposures.Add(p2.ccd, exposure);
-                        UnivDrvCommand((SBIG.PAR_COMMAND)request.command, p2);
-                        response.payload = null;
-                        break;
-                    case "CC_QUERY_TEMPERATURE_STATUS":
-                        SBIG.QueryTemperatureStatusParams p3 = (SBIG.QueryTemperatureStatusParams)request.parameters;
-                        SBIG.QueryTemperatureStatusResults2 result3 = new SBIG.QueryTemperatureStatusResults2();
-                        UnivDrvCommand((SBIG.PAR_COMMAND)request.command, p3, out result3);
-                        response.payload = result3;
-                        break;
-                    case "CCD_INFO":
-                        SBIG.GetCCDInfoParams p4 = (SBIG.GetCCDInfoParams)request.parameters;
-                        SBIG.GetCCDInfoResults0 result4 = new SBIG.GetCCDInfoResults0();
-                        UnivDrvCommand((SBIG.PAR_COMMAND)request.command, p4, out result4);
-                        response.payload = result4;
-                        break;
-                    case "CCD_INFO_EXTENDED":
-                        SBIG.GetCCDInfoParams p5 = (SBIG.GetCCDInfoParams)request.parameters;
-                        SBIG.GetCCDInfoResults2 result5 = new SBIG.GetCCDInfoResults2();
-                        UnivDrvCommand((SBIG.PAR_COMMAND)request.command, p5, out result5);
-                        response.payload = result5;
-                        break;
-                    case "CCD_INFO_EXTENDED2":
-                        SBIG.GetCCDInfoParams p6 = (SBIG.GetCCDInfoParams)request.parameters;
-                        SBIG.GetCCDInfoResults4 result6 = new SBIG.GetCCDInfoResults4();
-                        UnivDrvCommand((SBIG.PAR_COMMAND)request.command, p6, out result6);
-                        response.payload = result6;
-                        break;
-                    case "CCD_INFO_EXTENDED3":
-                        SBIG.GetCCDInfoParams p7 = (SBIG.GetCCDInfoParams)request.parameters;
-                        SBIG.GetCCDInfoResults6 result7 = new SBIG.GetCCDInfoResults6();
-                        UnivDrvCommand((SBIG.PAR_COMMAND)request.command, p7, out result7);
-                        response.payload = result7;
-                        break;
-                    case "CCD_INFO_EXTENDED_PIXCEL":
-                        SBIG.GetCCDInfoParams p10 = (SBIG.GetCCDInfoParams)request.parameters;
-                        SBIG.GetCCDInfoResults3 result10 = new SBIG.GetCCDInfoResults3();
-                        UnivDrvCommand((SBIG.PAR_COMMAND)request.command, p10, out result10);
-                        response.payload = result10;
-                        break;
-                    case "EndReadout":
-                        SBIG.CCD_REQUEST ccd = (SBIG.CCD_REQUEST)request.parameters;
-                        if (exposures.Keys.Contains(ccd)) exposures.Remove(ccd);
-                        EndReadout(ccd);
-                        response.payload = null;
-                        break;
-                    case "ExposureInProgress":
-                        bool temp = false;
-                        SBIG.StartExposureParams2 p11 = (SBIG.StartExposureParams2)request.parameters;
-                        if (exposures.Keys.Contains(p11.ccd))
-                        {
-                            long duration = (long)exposures[p11.ccd].duration;
+                            long duration = (long)exposures[inProgressParams.ccd].duration;
                             if (duration >= SBIG.EXP_FAST_READOUT) duration -= SBIG.EXP_FAST_READOUT;
-                            if (DateTime.Now < (exposures[p11.ccd].start + new TimeSpan(duration * TimeSpan.TicksPerSecond / 100)))
-                                temp = true;
+                            if (DateTime.Now < (exposures[inProgressParams.ccd].start + new TimeSpan(duration * TimeSpan.TicksPerSecond / 100)))
+                                inProgress = true;
                         }
-                        if (!temp)
-                            temp = ExposureInProgress(p11.ccd); // Double check wth the camera
-                        response.payload = temp;
+                        if (!inProgress)
+                            inProgress = ExposureInProgress(inProgressParams.ccd); // Double check with the camera
+                        response.payload = inProgress;
                         break;
-                    case "ReadoutData":
-                        SBIG.StartExposureParams2 p8 = (SBIG.StartExposureParams2)request.parameters;
-                        if (exposures.Keys.Contains(p8.ccd)) exposures.Remove(p8.ccd);
-                        var data = new UInt16[p8.width * p8.height];
+                    case MessageType.ReadoutData:
+                        SBIG.StartExposureParams2 readoutParams = (SBIG.StartExposureParams2)request.parameters;
+                        if (exposures.Keys.Contains(readoutParams.ccd)) exposures.Remove(readoutParams.ccd);
+                        var data = new UInt16[readoutParams.width * readoutParams.height];
                         try
                         {
-                            Utils.AcquireLock(ref lockAccess);
-                            ReadoutDataAndEnd(p8, ref data);
+                            lock (_accessLockObject)
+                            {
+                                ReadoutDataAndEnd(readoutParams, ref data);
+                            }
                         }
                         catch (Exception ex)
                         {
                             debug.LogMessage("SBIGService HandleMessage", "Error: " + Utils.DisplayException(ex));
-                        }
-                        finally
-                        {
-                            Utils.ReleaseLock(ref lockAccess);
                         }
                         response.payload = data;
                         break;
-                    case "CC_CFW":
-                        SBIG.CFWParams p9 = (SBIG.CFWParams)request.parameters;
-                        SBIG.CFWResults result9 = new SBIG.CFWResults();
-                        UnivDrvCommand((SBIG.PAR_COMMAND)request.command, p9, out result9);
-                        response.payload = result9;
+                    case MessageType.CcfCfw:
+                        SBIG.CFWParams cfwParams = (SBIG.CFWParams)request.parameters;
+                        SBIG.CFWResults cfwResult = new SBIG.CFWResults();
+                        UnivDrvCommand((SBIG.PAR_COMMAND)request.command, cfwParams, out cfwResult);
+                        response.payload = cfwResult;
                         break;
                     default:
                         throw new NotImplementedException("Message type " + request.type + " not implemented");
-                        break;
                 }
                 return response;
             }
@@ -256,20 +239,11 @@ namespace ASCOM.HomeMade.SBIGCommon
             if (!cameraFound && String.IsNullOrEmpty(ipAddress))
             {
                 debug.LogMessage("Connected Set", $"No camera found");
-                if (String.IsNullOrEmpty(ipAddress))
+                try
                 {
-                    try
-                    {
-                        debug.LogMessage("Disconnect", "Disconnecting device");
-                        // clean up
-                        SBIG.UnivDrvCommand(SBIG.PAR_COMMAND.CC_CLOSE_DRIVER);
-                    }
-                    catch (Exception e)
-                    {
-                        //debug.LogMessage("Connected", "Error: " + DisplayException(e));
-                    }
-
+                    SBIG.UnivDrvCommand(SBIG.PAR_COMMAND.CC_CLOSE_DRIVER);
                 }
+                catch (Exception) { }
                 return false;
             }
             else
@@ -288,8 +262,6 @@ namespace ASCOM.HomeMade.SBIGCommon
                     SBIG.UnivDrvCommand(SBIG.PAR_COMMAND.CC_OPEN_DEVICE, 
                         new SBIG.OpenDeviceParams(ipAddress));
                 }
-                var cameraType = SBIG.EstablishLink();
-
                 CameraType = SBIG.EstablishLink();
                 debug.LogMessage("Connected Set", $"Connected to camera");
 
@@ -345,23 +317,14 @@ namespace ASCOM.HomeMade.SBIGCommon
 
         public void AbortExposure(SBIG.StartExposureParams2 sep2)
         {
-            try
+            lock (_readoutLockObject)
             {
-                Utils.AcquireLock(ref lockReadout);
                 UnivDrvCommand(
                 SBIG.PAR_COMMAND.CC_END_EXPOSURE,
                 new SBIG.EndExposureParams()
                 {
                     ccd = sep2.ccd
                 });
-            }
-            catch (Exception)
-            {
-                throw;
-            }
-            finally
-            {
-                Utils.ReleaseLock(ref lockReadout);
             }
         }
 
@@ -381,37 +344,18 @@ namespace ASCOM.HomeMade.SBIGCommon
 
         public void ReadoutData(SBIG.StartExposureParams2 sep2, ref UInt16[,] data)
         {
-            try
+            lock (_readoutLockObject)
             {
-                Utils.AcquireLock(ref lockReadout);
                 SBIG.ReadoutData(sep2, ref data);
-            }
-            catch (Exception)
-            {
-                throw;
-            }
-            finally
-            {
-                Utils.ReleaseLock(ref lockReadout);
             }
         }
 
-        private static bool lockReadout = false;
         public void ReadoutDataAndEnd(SBIG.StartExposureParams2 sep2, ref UInt16[] data)
         {
-            try
+            lock (_readoutLockObject)
             {
-                Utils.AcquireLock(ref lockReadout);
                 SBIG.ReadoutData(sep2, ref data);
                 EndReadout(sep2.ccd);
-            }
-            catch (Exception)
-            {
-                throw;
-            }
-            finally
-            {
-                Utils.ReleaseLock(ref lockReadout);
             }
         }
     }

--- a/ASCOM.HomeMade.SBIGCommon/SBIGRequest.cs
+++ b/ASCOM.HomeMade.SBIGCommon/SBIGRequest.cs
@@ -25,9 +25,29 @@ using SbigSharp;
 
 namespace ASCOM.HomeMade.SBIGCommon
 {
+    public enum MessageType
+    {
+        Ping,
+        Connect,
+        Disconnect,
+        AbortExposure,
+        SetTemperatureRegulation,
+        StartExposure,
+        QueryTemperatureStatus,
+        CcdInfo,
+        CcdInfoExtended,
+        CcdInfoExtended2,
+        CcdInfoExtended3,
+        CcdInfoExtendedPixcel,
+        EndReadout,
+        ExposureInProgress,
+        ReadoutData,
+        CcfCfw
+    }
+
     public class SBIGRequest
     {
-        public string type;
+        public MessageType type;
         public ushort command;
         public object parameters = null;
     }

--- a/ASCOM.HomeMade.SBIGCommon/Utils.cs
+++ b/ASCOM.HomeMade.SBIGCommon/Utils.cs
@@ -17,13 +17,9 @@
  *
  */
 using System;
-using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.IO.Compression;
-using System.Linq;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace ASCOM.HomeMade.SBIGCommon
@@ -77,33 +73,9 @@ namespace ASCOM.HomeMade.SBIGCommon
             return output.ToArray();
         }
 
-        private static TimeSpan LOCKTIMEOUT = TimeSpan.FromSeconds(20);
-        public static void AcquireLock(ref bool lockObject)
-        {
-            DateTime start = DateTime.Now;
-            while (lockObject)
-            {
-                if (DateTime.Now >= (start + LOCKTIMEOUT))
-                {
-                    throw new TimeoutException("Timed out acquiring lock");
-                }
-                else
-                {
-                    Thread.Sleep(10);
-                }
-            }
-            lockObject = true;
-        }
-
-        public static void ReleaseLock(ref bool lockObject)
-        {
-            lockObject = false;
-        }
-
         public static Array RotateMatrixCounterClockwiseAndConvertToInt(UInt16[,] oldMatrix)
         {
             Array newMatrix = Array.CreateInstance(typeof(int), oldMatrix.GetLength(1), oldMatrix.GetLength(0));
-            //int[,] newMatrix = new int[oldMatrix.GetLength(1), oldMatrix.GetLength(0)];
             int newColumn, newRow = 0;
             for (int oldColumn = 0; oldColumn < oldMatrix.GetLength(1); oldColumn++)
             {
@@ -131,99 +103,5 @@ namespace ASCOM.HomeMade.SBIGCommon
             return result;
         }
 
-        /*
-        private static int[][] SaveImageData(int width, int height, int[] data)
-        {
-            int[][] bimg = new int[height][];
-
-            for (int y = 0; y < height; y++)
-            {
-                bimg[y] = new int[width];
-
-                for (int x = 0; x < width; x++)
-                {
-                    bimg[y][x] = (int)Math.Max((int)0, data[x + (height - y - 1) * width]);
-                }
-            }
-
-            return bimg;
-        }
-
-        public static void SaveFitsFrame(int frameNo, string fileName, int width, int height, int[] framePixels, DateTime timeStamp, float exposureSeconds)
-        {
-            SaveFitsFrame(frameNo, fileName, width, height, framePixels, timeStamp, exposureSeconds, timeStamp.ToLongTimeString(), new Dictionary<string, Tuple<string, string>>());
-        }
-
-        public static void SaveFitsFrame(
-            int frameNo,
-            string fileName,
-            int width,
-            int height,
-            int[] framePixels,
-            DateTime timeStamp,
-            float exposureSeconds,
-            string timeStampComment,
-            Dictionary<string, Tuple<string, string>> additionalFileHeaders)
-        {
-            Fits f = new Fits();
-
-            object data = (object)SaveImageData(width, height, framePixels);
-
-            BasicHDU imageHDU = Fits.MakeHDU(data);
-
-            nom.tam.fits.Header hdr = imageHDU.Header;
-            hdr.AddValue("SIMPLE", "T", null);
-
-            hdr.AddValue("BITPIX", 32, null);
-
-            hdr.AddValue("BZERO", 32768, null);
-            hdr.AddValue("BSCALE", 1, null);
-
-            hdr.AddValue("NAXIS", 2, null);
-            hdr.AddValue("NAXIS1", width, null);
-            hdr.AddValue("NAXIS2", height, null);
-
-            hdr.AddValue("EXPOSURE", exposureSeconds.ToString("0.000", CultureInfo.InvariantCulture), "Exposure, seconds");
-
-            hdr.AddValue("DATE-OBS", timeStamp.ToString("yyyy-MM-ddTHH:mm:ss.fff", CultureInfo.InvariantCulture), timeStampComment);
-
-            hdr.AddValue("FRAMENO", frameNo, null);
-
-            foreach (var kvp in additionalFileHeaders)
-            {
-                hdr.AddValue(kvp.Key, kvp.Value.Item1, kvp.Value.Item2);
-            }
-
-            hdr.AddValue("END", null, null);
-
-            f.AddHDU(imageHDU);
-
-            // Write a FITS file.
-            using (BufferedFile bf = new BufferedFile(fileName, FileAccess.ReadWrite, FileShare.ReadWrite))
-            {
-                f.Write(bf);
-                bf.Flush();
-            }
-        }
-
-        public static int[] To1DArray(int[,] input)
-        {
-            // Step 1: get total size of 2D array, and allocate 1D array.
-            int size = input.Length;
-            int[] result = new int[size];
-
-            // Step 2: copy 2D array elements into a 1D array.
-            int write = 0;
-            for (int z = input.GetUpperBound(1); z >= 0; z--)
-            {
-                for (int i = 0; i <= input.GetUpperBound(0); i++)
-                {
-                    result[write++] = input[i, z];
-                }
-            }
-            // Step 3: return the new array.
-            return result;
-        }
-        */
     }
 }

--- a/ASCOM.HomeMade.SBIGHub/ISBIGCamera.cs
+++ b/ASCOM.HomeMade.SBIGHub/ISBIGCamera.cs
@@ -46,6 +46,7 @@ namespace ASCOM.HomeMade.SBIGHub
         public Array cameraImageArray;
         public object[,] cameraImageArrayVariant;
         public bool FastReadoutRequested = false;
+        public Exception LastError = null;
 
         public short BinX
         {


### PR DESCRIPTION
Phase 1 – Critical bug fixes:
- Fix silent exception swallowing in ImageTakerThread.TakeImage(); on failure
  the camera state is now reset to cameraIdle, cameraImageReady cleared, and
  the exception stored in the new ISBIGCamera.LastError field instead of being
  silently discarded.
- Remove duplicate SBIG.EstablishLink() call in SBIGHandler.Connect().
- Replace unsafe volatile-bool spin-locks (AcquireLock/ReleaseLock) with
  proper lock() blocks using three dedicated static readonly lock objects.
  Delete the now-unused AcquireLock/ReleaseLock helpers from Utils.

Phase 2 – Code quality:
- Add MessageType enum to SBIGRequest and switch SBIGHandler.HandleMessage()
  and all SBIGClient call sites from string literals to enum values, giving
  compile-time type safety.  Rename opaque p0-p11 locals to descriptive names.
- Extract magic number 500 in MemoryController to MaxMemoryMB constant;
  extract temperature cache TTL in SBIGCamera to TemperatureCacheTtlMs const.
- Fix Debug.LogMessage timestamp: capture DateTime.Now once and format with
  a standard format string instead of seven separate property accesses.

Phase 3 – Cleanup:
- Remove large commented-out FITS-writing block from Utils.cs.
- Remove dead commented lines in ImageTakerThread.cs.
- Simplify CommandBlind/CommandBool/CommandString stub methods in SBIGCamera.cs
  by removing unreachable code and stale template comments.
- Flatten redundant nested null-check in SBIGHandler.Connect().
- Remove unused using directives from Utils.cs.

https://claude.ai/code/session_01Q2p9xnFfUHNrgREjzPWEWf